### PR TITLE
Update PhalconFrameworkPaginatorAdapter.php

### DIFF
--- a/src/Pagination/PhalconFrameworkPaginatorAdapter.php
+++ b/src/Pagination/PhalconFrameworkPaginatorAdapter.php
@@ -79,8 +79,7 @@ class PhalconFrameworkPaginatorAdapter implements PaginatorInterface
      */
     public function getPerPage()
     {
-        return $this->paginator->getLimit();
-
+        return $this->getPaginator()->items->count();
     }
 
     /**
@@ -112,7 +111,6 @@ class PhalconFrameworkPaginatorAdapter implements PaginatorInterface
      */
     public function getPaginator()
     {
-        
-        return $this->paginator->getPaginate();
+        return $this->paginator;
     }
 }

--- a/test/Pagination/PhalconFrameworkPaginatorAdapterTest.php
+++ b/test/Pagination/PhalconFrameworkPaginatorAdapterTest.php
@@ -30,7 +30,7 @@ class PhalconFrameworkPaginatorAdapterTest extends \PHPUnit_Framework_TestCase
         $paginator->shouldReceive('total')->andReturn($total);
         $paginator->shouldReceive('getPaginate')->andReturn((object) $paginate);
 
-        $adapter = new PhalconFrameworkPaginatorAdapter($paginator);
+        $adapter = new PhalconFrameworkPaginatorAdapter($paginator->getPaginate());
 
         $this->assertInstanceOf('League\Fractal\Pagination\PaginatorInterface', $adapter);
         $this->assertSame($currentPage, $adapter->getCurrentPage());


### PR DESCRIPTION
Calling `getPagination()` method multiple times is a terrible idea and in some cases can greatly decrease application performance.
Every method that uses `getPaginator()` in total generates 10 more queries to database (5 counts and 5 selects) than it should.
